### PR TITLE
fix(authenticator): prevent throw 401 every time

### DIFF
--- a/lib/error/authentication.js
+++ b/lib/error/authentication.js
@@ -1,0 +1,13 @@
+'use strict';
+
+class AuthenticationError extends Error {
+  constructor(message) {
+    super(message);
+
+    this.name = this.constructor.name;
+    this.message = message;
+    this.stack = (new Error(message)).stack;
+  }
+}
+
+module.exports = AuthenticationError;

--- a/lib/koa-authenticator.js
+++ b/lib/koa-authenticator.js
@@ -19,10 +19,10 @@ module.exports = function(escherConfig = {}, logger) {
           logger.error('authentication_request_error', ex.message, ex);
         }
 
-        this.throw(401, ex.message);
+        return this.throw(ex.message, 401);
       }
 
-      this.throw(ex);
+      throw ex;
     }
   };
 };

--- a/lib/koa-authenticator.js
+++ b/lib/koa-authenticator.js
@@ -1,6 +1,7 @@
 'use strict';
 
 let Authenticator = require('./request-authenticator');
+let AuthenticationError = require('./error/authentication');
 
 module.exports = function(escherConfig = {}, logger) {
   return function*(next) {
@@ -13,11 +14,15 @@ module.exports = function(escherConfig = {}, logger) {
         yield next;
       }
     } catch (ex) {
-      if (logger && logger.error) {
-        logger.error('authentication_request_error', ex.message, ex);
+      if (ex instanceof AuthenticationError) {
+        if (logger && logger.error) {
+          logger.error('authentication_request_error', ex.message, ex);
+        }
+
+        this.throw(401, ex.message);
       }
 
-      this.throw(401, ex.message);
+      this.throw(ex);
     }
   };
 };

--- a/lib/request-authenticator.js
+++ b/lib/request-authenticator.js
@@ -2,6 +2,7 @@
 
 var Escher = require('escher-auth');
 var KeyPool = require('escher-keypool');
+var AuthenticationError = require('./error/authentication');
 
 
 class RequestAuthenticator {
@@ -24,7 +25,11 @@ class RequestAuthenticator {
   *authenticate() {
     this._validate();
 
-    yield this._authenticate();
+    try {
+      yield this._authenticate();
+    } catch (error) {
+      throw new AuthenticationError(error.message);
+    }
   }
 
   _validate() {

--- a/tests/koa-authenticator.spec.js
+++ b/tests/koa-authenticator.spec.js
@@ -5,6 +5,7 @@ let expect = require('chai').expect;
 let sinon = require('sinon');
 let KeyPool = require('escher-keypool');
 let Escher = require('escher-auth');
+let AuthenticationError = require('../lib/error/authentication');
 
 describe('Koa Escher Request Authenticator Middleware', function() {
   let next;
@@ -62,7 +63,7 @@ describe('Koa Escher Request Authenticator Middleware', function() {
 
 
   it('should throw HTTP 401 in case of problem during request capture', function*() {
-    let error = new Error('Request capture error');
+    let error = new AuthenticationError('Request capture error');
     let rejectedData = Promise.reject(error);
     let context = createContext(rejectedData);
 
@@ -74,7 +75,7 @@ describe('Koa Escher Request Authenticator Middleware', function() {
 
 
   it('should throw HTTP 401 in case of authentication problem', function*() {
-    let error = new Error('Test escher error');
+    let error = new AuthenticationError('Test escher error');
     let resolvedData = Promise.resolve('test body');
     let context = createContext(resolvedData);
     escherStub.authenticate.throws(error);

--- a/tests/koa-request.spec.js
+++ b/tests/koa-request.spec.js
@@ -31,6 +31,21 @@ describe('Koa Escher Authentication Middleware suite', function() {
       .expect(401, 'Test escher error', done);
   });
 
+  it('should return with HTTP 400 in case of application error', function(done) {
+    escherStub.authenticate.returns('test_escher_keyid');
+
+    /*eslint-disable*/
+    app.use(function*() {
+      this.throw('Test application error', 400);
+    });
+    /*eslint-enable*/
+
+    request(app.listen())
+      .post('/')
+      .send('{"foo": "bar"}')
+      .expect(400, 'Test application error', done);
+  });
+
   it('should run controller if request is a valid escher request', function(done) {
     escherStub.authenticate.returns('test_escher_keyid');
 

--- a/tests/koa-request.spec.js
+++ b/tests/koa-request.spec.js
@@ -31,7 +31,7 @@ describe('Koa Escher Authentication Middleware suite', function() {
       .expect(401, 'Test escher error', done);
   });
 
-  it('should return with HTTP 400 in case of application error', function(done) {
+  it('should return with the original error in case of application error', function(done) {
     escherStub.authenticate.returns('test_escher_keyid');
 
     /*eslint-disable*/


### PR DESCRIPTION
Prevent escher authenticator to throw HTTP 401 Authentication error every time when an application error is thrown.
