### PR TITLE
feat(request): escher access key id added to Koa context

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ let app = new Koa();
 app.use(bodyParser());
 app.use(escherAuth.authenticator(escherConfig));
 app.use(function(ctx) {
-  ctx.body = 'Hello world';
+  ctx.body = `Hello world, ${ctx.escherAccessKeyId}!`;
 });
 ```
+The access key id used to authenticate the request will be available on the context as `escherAccessKeyId`
 
 ### Environment variables
 

--- a/lib/koa-authenticator.js
+++ b/lib/koa-authenticator.js
@@ -11,7 +11,7 @@ module.exports = function(escherConfig, logger) {
     const authenticator = new Authenticator(escherConfig, ctx);
 
     try {
-      await authenticator.authenticate();
+      ctx.escherAccessKeyId = await authenticator.authenticate();
     } catch (ex) {
       if (ex instanceof AuthenticationError) {
         if (logger && logger.error) {

--- a/lib/request-authenticator.js
+++ b/lib/request-authenticator.js
@@ -26,7 +26,7 @@ class RequestAuthenticator {
     this._validate();
 
     try {
-      this._authenticate();
+      return this._authenticate();
     } catch (error) {
       throw new AuthenticationError(error.message);
     }

--- a/tests/koa-request.spec.js
+++ b/tests/koa-request.spec.js
@@ -43,8 +43,6 @@ describe('Koa Escher Authentication Middleware suite', function() {
 
 
   it('should return with the original error in case of application error', function(done) {
-    escherStub.authenticate.returns('test_escher_keyid');
-
     app.use(function(ctx) {
       ctx.throw(400, 'Test application error');
     });
@@ -57,8 +55,6 @@ describe('Koa Escher Authentication Middleware suite', function() {
 
 
   it('should run controller if request is a valid escher request', function(done) {
-    escherStub.authenticate.returns('test_escher_keyid');
-
     app.use(function(ctx) {
       ctx.body = 'test message from controller';
     });
@@ -70,9 +66,21 @@ describe('Koa Escher Authentication Middleware suite', function() {
   });
 
 
-  it('should handle get requests without raw body', function(done) {
-    escherStub.authenticate.returns('test_escher_keyid');
+  it('should assigns the access key id to the context returned by authenticate for valid requests', function(done) {
+    escherStub.authenticate.resolves('test_escher_keyid');
 
+    app.use(function(ctx) {
+      ctx.body = `keyId: "${ctx.escherAccessKeyId}"`;
+    });
+
+    request(server)
+      .post('/')
+      .send('{"foo": "bar"}')
+      .expect(200, 'keyId: "test_escher_keyid"', done);
+  });
+
+
+  it('should handle get requests without raw body', function(done) {
     app.use(function(ctx) {
       ctx.body = 'test message from controller';
     });


### PR DESCRIPTION
in case you need to know the key of the service that initiated the request.
This way we don't need to duplicate the code just to parse it out from "Credentials" header.

AIM-005