### PR TITLE
Allow HEAD request without body

### DIFF
--- a/lib/request-authenticator.js
+++ b/lib/request-authenticator.js
@@ -33,7 +33,7 @@ class RequestAuthenticator {
   }
 
   _validate() {
-    const methodsAllowedWithoutBody = ['GET', 'DELETE'];
+    const methodsAllowedWithoutBody = ['GET', 'HEAD', 'DELETE'];
     if (methodsAllowedWithoutBody.includes(this._context.request.method)) {
       return;
     }

--- a/tests/koa-request.spec.js
+++ b/tests/koa-request.spec.js
@@ -91,14 +91,24 @@ describe('Koa Escher Authentication Middleware suite', function() {
   });
 
 
-  it('should handle delete requests without raw body', function(done) {
-    app.use(function(ctx) {
+  it('should handle delete requests without raw body', function (done) {
+    app.use(function (ctx) {
       ctx.body = 'valid body';
     });
 
     request(server)
       .delete('/')
       .expect(200, 'valid body', done);
+  });
+
+
+  it('should handle head requests without raw body', function (done) {
+    app.use(function (ctx) {
+      ctx.body = 'this response body will not be returned for a HEAD request';
+    });
+    request(server)
+      .head('/')
+      .expect(200, undefined, done);
   });
   
 });


### PR DESCRIPTION
HEAD requests are supposed to work the same as GET according to [RFC-7231](https://tools.ietf.org/html/rfc7231#section-4.3.2).