### PR TITLE
feat(request-authenticator): accept empty POST request, validate body…

### DIFF
--- a/lib/request-authenticator.js
+++ b/lib/request-authenticator.js
@@ -38,7 +38,7 @@ class RequestAuthenticator {
       return;
     }
 
-    if (this._context.request.rawBody === undefined) {
+    if (this._context.request.body === undefined) {
       throw new Error('Context is not decorated. Use koa-bodyparser middleware first.');
     }
   }

--- a/tests/koa-authenticator.spec.js
+++ b/tests/koa-authenticator.spec.js
@@ -22,6 +22,7 @@ describe('Koa Escher Request Authenticator Middleware', function() {
     return {
       throw: sinon.stub(),
       request: {
+        body: data,
         rawBody: data
       }
     };

--- a/tests/koa-request.spec.js
+++ b/tests/koa-request.spec.js
@@ -65,6 +65,16 @@ describe('Koa Escher Authentication Middleware suite', function() {
       .expect(200, 'test message from controller', done);
   });
 
+  it('should run controller if request is a valid escher post request without body', function(done) {
+    app.use(function(ctx) {
+      ctx.body = 'test message from controller';
+    });
+
+    request(server)
+      .post('/')
+      .expect(200, 'test message from controller', done);
+  });
+
 
   it('should assigns the access key id to the context returned by authenticate for valid requests', function(done) {
     escherStub.authenticate.resolves('test_escher_keyid');
@@ -91,8 +101,8 @@ describe('Koa Escher Authentication Middleware suite', function() {
   });
 
 
-  it('should handle delete requests without raw body', function (done) {
-    app.use(function (ctx) {
+  it('should handle delete requests without raw body', function(done) {
+    app.use(function(ctx) {
       ctx.body = 'valid body';
     });
 
@@ -102,13 +112,13 @@ describe('Koa Escher Authentication Middleware suite', function() {
   });
 
 
-  it('should handle head requests without raw body', function (done) {
-    app.use(function (ctx) {
+  it('should handle head requests without raw body', function(done) {
+    app.use(function(ctx) {
       ctx.body = 'this response body will not be returned for a HEAD request';
     });
     request(server)
       .head('/')
       .expect(200, undefined, done);
   });
-  
+
 });


### PR DESCRIPTION
… based on request.body instead of request.rawBody

AA-7869

Co-authored-by: Laszlo Veraszto <laszlo.veraszto@emarsys.com>



Based on the documentation of the koa-bodyparser it is better to validate the usage of the bodyparser by "request.body"
https://www.npmjs.com/package/koa-bodyparser#usage

In the old version (>3.0.0) the empty POST body was not allowed, but in a previous version of koa-escher-auth 2.5.4 it was.
